### PR TITLE
add support for memory binding selection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,12 @@ HEADERS := $(wildcard *.hpp)
 SOURCES := $(wildcard *.cpp)
 OBJECTS := $(SOURCES:.cpp=.o)
 EXECUTABLE := scheduler
-# NUMACTL_EXE := numactl --membind=0
 
 RUNTIME_LOG_FLAGS := \
 	--log=fifo_scheduler.thres:debug \
 	--log=heft_scheduler.thres:debug \
-	--log=eft_scheduler.thres:debug
+	--log=eft_scheduler.thres:debug \
+	--log=hardware.thres:debug
 
 # Directories
 TEST_DIR := ./tests
@@ -173,7 +173,7 @@ $(EVALUATION_CASES): %: $(EXECUTABLE)
 				--template "$$template" \
 				--output_file "$${CONFIG_FILE}.json" > "$${LOG_FILE}" 2>&1; \
 			GEN_STATUS=$$?; \
-			$(NUMACTL_EXE) ./$(EXECUTABLE) $(RUNTIME_LOG_FLAGS) "$$CONFIG_FILE.json" >> "$$LOG_FILE" 2>&1; \
+			./$(EXECUTABLE) $(RUNTIME_LOG_FLAGS) "$$CONFIG_FILE.json" >> "$$LOG_FILE" 2>&1; \
 			EXEC_STATUS=$$?; \
 			$(PYTHON_EXEC) $(TEST_VALIDATOR_DIR)/validate_offsets.py "$${OUTPUT_FILE}.yaml"  >> "$$LOG_FILE" 2>&1; \
 			VAL_STATUS=$$?; \

--- a/common.hpp
+++ b/common.hpp
@@ -124,6 +124,10 @@ struct common_s
     scheduler_type_t scheduler_type;
     mapper_type_t mapper_type;
 
+    std::string mapper_mem_policy_type;
+    hwloc_membind_policy_t mapper_mem_policy;
+    unsigned mapper_mem_bind_numa_node_id;
+
     // Locality information collections.
     name_to_address_t comm_name_to_address;
     name_to_numa_ids_t comm_name_to_numa_ids_r;

--- a/hardware.hpp
+++ b/hardware.hpp
@@ -7,6 +7,7 @@ int get_hwloc_numa_id_by_core_id(const common_t *common, int hwloc_core_id);
 double get_hwloc_core_performance_by_id(const common_t *common, int hwloc_core_id);
 std::vector<int> get_hwloc_numa_ids_by_address(const common_t *common, char *address, size_t size);
 
+void set_hwloc_thread_mem_policy(const common_t *common);
 std::string get_hwloc_thread_mem_policy(const common_t *common);
 thread_locality_t get_hwloc_thread_locality(const common_t *common);
 

--- a/mapper_bare_metal.cpp
+++ b/mapper_bare_metal.cpp
@@ -81,6 +81,9 @@ void *mapper_bare_metal_thread_function(void *arg)
 {
     thread_data_t *data = (thread_data_t *)arg;
 
+    // Set the thread memory policy.
+    set_hwloc_thread_mem_policy(data->common);
+
     XBT_INFO("Process ID: %d, Thread ID: %d, Task ID: %s, Core ID: %d => message: started.", getpid(), gettid(),
              data->exec->get_cname(), get_hwloc_core_id_by_pu_id(data->common, sched_getcpu()));
 

--- a/runtime.cpp
+++ b/runtime.cpp
@@ -83,6 +83,30 @@ void initialize_common(common_t *common, const nlohmann::json &data) {
         throw std::runtime_error("Unsupported clock frequency type: " + clock_frequency_type);
     }
 
+    std::string mapper_mem_policy_type = data["mapper_mem_policy_type"];
+
+    if (mapper_mem_policy_type == "default") {
+        common->mapper_mem_policy = HWLOC_MEMBIND_DEFAULT;
+        common->mapper_mem_bind_numa_node_id = 0; // Not used, but initialized.
+    } else if (mapper_mem_policy_type == "firsttouch") {
+        common->mapper_mem_policy = HWLOC_MEMBIND_FIRSTTOUCH;
+        common->mapper_mem_bind_numa_node_id = 0; // Not used, but initialized.
+    } else if (mapper_mem_policy_type == "bind") {
+        common->mapper_mem_policy = HWLOC_MEMBIND_BIND;
+        common->mapper_mem_bind_numa_node_id = data["mapper_mem_bind_numa_node_id"];
+    } else if (mapper_mem_policy_type == "interleave") {
+        common->mapper_mem_policy = HWLOC_MEMBIND_INTERLEAVE;
+        common->mapper_mem_bind_numa_node_id = 0; // Not used, but initialized.
+    } else if (mapper_mem_policy_type == "nexttouch") {
+        common->mapper_mem_policy = HWLOC_MEMBIND_NEXTTOUCH;
+        common->mapper_mem_bind_numa_node_id = 0; // Not used, but initialized.
+    } else if (mapper_mem_policy_type == "mixed") {
+        common->mapper_mem_policy = HWLOC_MEMBIND_MIXED;
+        common->mapper_mem_bind_numa_node_id = 0; // Not used, but initialized.
+    } else {
+        throw std::runtime_error("Unsupported memory policy type: " + mapper_mem_policy_type);
+    }
+
     common->log_base_name = data["log_base_name"];
     common->log_date_format = data["log_date_format"];
 


### PR DESCRIPTION
- Added `mapper_mem_policy_type: default | firsttouch | bind | interleave | nexttouch | mixed` to define the thread memory allocation policy.  
- Added `mapper_mem_bind_numa_node_id: int`, which applies only when `mapper_mem_policy_type` is set to `bind`, allowing memory allocations to be bound to a specific NUMA node.  